### PR TITLE
Allow api_key to be set

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,4 @@
+detectors:
+  ControlParameter:
+    exclude:
+      - Anthropic#self.api_key=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
+# Changelog
+
 ## [Unreleased]
 
 ## [0.1.0] - 2023-11-30
 
+### Added
+
 - Initial release
+
+[Unreleased]: https://github.com/d3d1rty/event_logger_rails/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/d3d1rty/event_logger_rails/releases/tag/0.1.0

--- a/README.md
+++ b/README.md
@@ -2,9 +2,19 @@
 
 Ruby bindings for the Anthropic API. This library is unofficial and is not affiliated with Anthropic PBC.
 
+The goal of this project is feature parity with Anthropic's Python SDK until an official Ruby SDK is available.
+
 ## Usage
 
-TODO: Write some code to use
+anthropic-rb will default to the value of the `ANTHROPIC_API_KEY` environment variable. However, you may initialize the library with your API key:
+
+```ruby
+require 'anthropic-rb'
+
+Anthropic.setup do |config|
+  config.api_key = 'YOUR_API_KEY'
+end
+```
 
 ## Installation
 

--- a/lib/anthropic.rb
+++ b/lib/anthropic.rb
@@ -2,8 +2,22 @@
 
 require_relative 'anthropic/version'
 
+##
+# Namespace for anthropic-rb gem
 module Anthropic
   ##
   # Default error class
   class Error < StandardError; end
+
+  def self.setup
+    yield self
+  end
+
+  def self.api_key
+    @api_key
+  end
+
+  def self.api_key=(api_key = nil)
+    @api_key = api_key || ENV.fetch('ANTHROPIC_API_KEY', nil)
+  end
 end

--- a/spec/lib/anthropic_spec.rb
+++ b/spec/lib/anthropic_spec.rb
@@ -4,4 +4,44 @@ RSpec.describe Anthropic do
   it 'has a version number' do
     expect(Anthropic::VERSION).not_to be_nil
   end
+
+  describe '.setup' do
+    subject(:setup) do
+      described_class.setup do |anthropic|
+        anthropic.api_key = api_key
+      end
+    end
+
+    let(:api_key) { 'foobar' }
+
+    it 'sets the provided values' do
+      setup
+      expect(described_class.api_key).to eq(api_key)
+    end
+  end
+
+  describe '.api_key' do
+    subject(:call_method) { described_class.api_key }
+
+    let(:api_key) { 'foobar' }
+
+    before do
+      described_class.api_key = api_key
+    end
+
+    it 'returns the API key' do
+      expect(call_method).to eq(api_key)
+    end
+  end
+
+  describe '.api_key=' do
+    subject(:call_method) { described_class.api_key = api_key }
+
+    let(:api_key) { 'foobar' }
+
+    it 'returns the API key' do
+      call_method
+      expect(described_class.api_key).to eq(api_key)
+    end
+  end
 end


### PR DESCRIPTION
## Description

This PR allows the api_key to be provided in a setup block.

## Testing

Follow these steps to test this PR:

* ...
* ...
* ...
