### PR TITLE
Add bindings for the completions API

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -2,3 +2,6 @@ detectors:
   ControlParameter:
     exclude:
       - Anthropic#self.api_key=
+  TooManyStatements:
+    exclude:
+      - 'Anthropic::Client#self.post'

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ end
 
 group :test do
   gem 'rspec'
+  gem 'webmock'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     anthropic-rb (0.1.0)
       httpx (>= 1.1.5)
+      json-schema (>= 4.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -17,6 +18,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     backport (1.2.0)
     base64 (0.2.0)
@@ -44,6 +47,8 @@ GEM
       reline (>= 0.3.8)
     jaro_winkler (1.5.6)
     json (2.6.3)
+    json-schema (4.1.1)
+      addressable (>= 2.8)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -66,6 +71,7 @@ GEM
       racc
     psych (5.1.1.1)
       stringio
+    public_suffix (5.0.4)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,8 @@ GEM
     childprocess (4.1.0)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
+    crack (0.4.5)
+      rexml
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
@@ -35,6 +37,7 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     e2mmap (0.1.0)
+    hashdiff (1.1.0)
     http-2-next (1.0.1)
     httpx (1.1.5)
       http-2-next (>= 1.0.1)
@@ -154,6 +157,10 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     yard (0.9.34)
 
 PLATFORMS
@@ -173,6 +180,7 @@ DEPENDENCIES
   rubocop-rspec
   solargraph
   solargraph-rails
+  webmock
 
 BUNDLED WITH
    2.4.18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     anthropic-rb (0.1.0)
+      httpx (>= 1.1.5)
 
 GEM
   remote: https://rubygems.org/
@@ -31,6 +32,9 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     e2mmap (0.1.0)
+    http-2-next (1.0.1)
+    httpx (1.1.5)
+      http-2-next (>= 1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     iniparse (1.5.0)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Anthropic.setup do |config|
 end
 ```
 
+You can also specify an API version to use by setting the `ANTHROPIC_API_VERSION` environment variable or during initialization:
+
+```ruby
+require 'anthropic-rb'
+
+Anthropic.setup do |config|
+  config.api_version = '2023-06-01'
+end
+```
+
+The default API version is `2023-06-01`.
+
 To make a request to the Completions API:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ Anthropic.setup do |config|
 end
 ```
 
+To make a request to the Completions API:
+
+```ruby
+Anthropic.completions.create(
+  model: 'claude-2',
+  max_tokens_to_sample: 200,
+  prompt: 'Human: Yo what up?\n\nAssistant:'
+)
+
+# Output =>
+# {
+#   completion: "Hello! Not much going on with me, just chatting. How about you?",
+#   stop_reason: "stop_sequence",
+#   model: "claude-2.1",
+#   stop: "\n\nHuman:",
+#   log_id: "2496914137c520ec2b4ae8315864bcf3a4c6ce9f2e3c96e13be4c004587313ca"
+# }
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/anthropic-rb.gemspec
+++ b/anthropic-rb.gemspec
@@ -11,10 +11,8 @@ Gem::Specification.new do |spec|
   spec.summary = 'Ruby bindings for the Anthropic API'
   spec.homepage = 'https://github.com/dickdavis/anthropic-rb'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.1'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
-
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/dickdavis/anthropic-rb'
   spec.metadata['changelog_uri'] = 'https://github.com/dickdavis/anthropic-rb/blob/main/CHANGELOG.md'
@@ -37,4 +35,7 @@ Gem::Specification.new do |spec|
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
   spec.metadata['rubygems_mfa_required'] = 'true'
+
+  spec.required_ruby_version = '>= 3.1'
+  spec.add_dependency 'httpx', '>= 1.1.5'
 end

--- a/anthropic-rb.gemspec
+++ b/anthropic-rb.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.1'
   spec.add_dependency 'httpx', '>= 1.1.5'
+  spec.add_dependency 'json-schema', '>= 4.1.1'
 end

--- a/lib/anthropic.rb
+++ b/lib/anthropic.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'httpx'
+require 'json'
+require 'json-schema'
 
 require_relative 'anthropic/client'
 require_relative 'anthropic/completions'

--- a/lib/anthropic.rb
+++ b/lib/anthropic.rb
@@ -25,6 +25,14 @@ module Anthropic
     @api_key = api_key || ENV.fetch('ANTHROPIC_API_KEY', nil)
   end
 
+  def self.api_version
+    @api_version
+  end
+
+  def self.api_version=(api_version = nil)
+    @api_version = api_version || ENV.fetch('ANTHROPIC_API_VERSION', '2023-06-01')
+  end
+
   def self.completions
     Completions.new
   end

--- a/lib/anthropic.rb
+++ b/lib/anthropic.rb
@@ -2,9 +2,9 @@
 
 require 'httpx'
 
-require_relative 'anthropic/version'
 require_relative 'anthropic/client'
 require_relative 'anthropic/completions'
+require_relative 'anthropic/version'
 
 ##
 # Namespace for anthropic-rb gem

--- a/lib/anthropic.rb
+++ b/lib/anthropic.rb
@@ -4,6 +4,7 @@ require 'httpx'
 
 require_relative 'anthropic/version'
 require_relative 'anthropic/client'
+require_relative 'anthropic/completions'
 
 ##
 # Namespace for anthropic-rb gem
@@ -22,5 +23,9 @@ module Anthropic
 
   def self.api_key=(api_key = nil)
     @api_key = api_key || ENV.fetch('ANTHROPIC_API_KEY', nil)
+  end
+
+  def self.completions
+    Completions.new
   end
 end

--- a/lib/anthropic.rb
+++ b/lib/anthropic.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require 'httpx'
+
 require_relative 'anthropic/version'
+require_relative 'anthropic/client'
 
 ##
 # Namespace for anthropic-rb gem

--- a/lib/anthropic.rb
+++ b/lib/anthropic.rb
@@ -17,20 +17,25 @@ module Anthropic
     yield self
   end
 
+  def self.reset
+    @api_key = nil
+    @api_version = nil
+  end
+
   def self.api_key
-    @api_key
+    @api_key || ENV.fetch('ANTHROPIC_API_KEY', nil)
   end
 
   def self.api_key=(api_key = nil)
-    @api_key = api_key || ENV.fetch('ANTHROPIC_API_KEY', nil)
+    @api_key = api_key
   end
 
   def self.api_version
-    @api_version
+    @api_version || ENV.fetch('ANTHROPIC_API_VERSION', '2023-06-01')
   end
 
   def self.api_version=(api_version = nil)
-    @api_version = api_version || ENV.fetch('ANTHROPIC_API_VERSION', '2023-06-01')
+    @api_version = api_version
   end
 
   def self.completions

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'httpx'
+
+module Anthropic
+  ##
+  # Error when the request is malformed.
+  class BadRequestError < StandardError; end
+  ##
+  # Error when the API key is invalid.
+  class AuthenticationError < StandardError; end
+  ##
+  # Error when the account does not have permission for the operation.
+  class PermissionDeniedError < StandardError; end
+  ##
+  # Error when the resource is not found.
+  class NotFoundError < StandardError; end
+  ##
+  # Error when the resource already exists.
+  class ConflictError < StandardError; end
+  ##
+  # Error when the resource cannot be processed.
+  class UnprocessableEntityError < StandardError; end
+  ##
+  # Error when the request exceeds the rate limit.
+  class RateLimitError < StandardError; end
+  ##
+  # Error when the server experienced an internal error.
+  class InternalServerError < StandardError; end
+
+  ##
+  # Provides a client for sending HTTP requests.
+  class Client
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    def self.post(url, data)
+      response = HTTPX.with(
+        headers: {
+          'Content-Type' => 'application/json',
+          'x-api-key' => Anthropic.api_key,
+          'anthropic-version' => '2023-06-01'
+        }
+      ).post(url, json: data)
+
+      response_body = JSON.parse(response.body, symbolize_names: true)
+
+      case response.status
+      when 200
+        response_body
+      when 400
+        raise Anthropic::BadRequestError, response_body
+      when 401
+        raise Anthropic::AuthenticationError, response_body
+      when 403
+        raise Anthropic::PermissionDeniedError, response_body
+      when 404
+        raise Anthropic::NotFoundError, response_body
+      when 409
+        raise Anthropic::ConflictError, response_body
+      when 422
+        raise Anthropic::UnprocessableEntityError, response_body
+      when 429
+        raise Anthropic::RateLimitError, response_body
+      when 500
+        raise Anthropic::InternalServerError, response_body
+      end
+    end
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
+  end
+end

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -31,13 +31,13 @@ module Anthropic
   ##
   # Provides a client for sending HTTP requests.
   class Client
-    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
     def self.post(url, data)
       response = HTTPX.with(
         headers: {
           'Content-Type' => 'application/json',
           'x-api-key' => Anthropic.api_key,
-          'anthropic-version' => '2023-06-01'
+          'anthropic-version' => Anthropic.api_version
         }
       ).post(url, json: data)
 
@@ -64,6 +64,6 @@ module Anthropic
         raise Anthropic::InternalServerError, response_body
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
   end
 end

--- a/lib/anthropic/completions.rb
+++ b/lib/anthropic/completions.rb
@@ -4,16 +4,49 @@ module Anthropic
   ##
   # Provides bindings for the Anthropic completions API
   class Completions
+    # Error for when the API version is not supported.
+    class UnsupportedApiVersionError < StandardError; end
+
+    V1_SCHEMA = {
+      type: 'object',
+      required: %w[model prompt max_tokens_to_sample],
+      properties: {
+        model: { type: 'string' },
+        prompt: { type: 'string' },
+        max_tokens_to_sample: { type: 'integer' },
+        stop_sequences: { type: 'array', items: { type: 'string' } },
+        temperature: { type: 'number' },
+        top_k: { type: 'integer' },
+        top_p: { type: 'number' },
+        metadata: { type: 'object' },
+        stream: { type: 'boolean' }
+      },
+      additionalProperties: false
+    }.freeze
+
     def initialize
       @endpoint = 'https://api.anthropic.com/v1/complete'
     end
 
-    def create(max_tokens_to_sample:, model:, prompt:)
-      Anthropic::Client.post(endpoint, { model:, prompt:, max_tokens_to_sample: })
+    def create(**params)
+      JSON::Validator.validate!(schema_for_api_version, params)
+      Anthropic::Client.post(endpoint, params)
+    rescue JSON::Schema::ValidationError => error
+      raise ArgumentError, error.message
     end
 
     private
 
     attr_reader :endpoint
+
+    def schema_for_api_version
+      api_version = Anthropic.api_version
+      case api_version
+      when '2023-06-01'
+        V1_SCHEMA
+      else
+        raise UnsupportedApiVersionError, "Unsupported API version: #{api_version}"
+      end
+    end
   end
 end

--- a/lib/anthropic/completions.rb
+++ b/lib/anthropic/completions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Anthropic
+  ##
+  # Provides bindings for the Anthropic completions API
+  class Completions
+    def initialize
+      @endpoint = 'https://api.anthropic.com/v1/complete'
+    end
+
+    def create(max_tokens_to_sample:, model:, prompt:)
+      Anthropic::Client.post(endpoint, { model:, prompt:, max_tokens_to_sample: })
+    end
+
+    private
+
+    attr_reader :endpoint
+  end
+end

--- a/spec/lib/anthropic/client_spec.rb
+++ b/spec/lib/anthropic/client_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe Anthropic::Client do
+  describe '.post' do
+    subject(:send_request) { described_class.post(url, data) }
+
+    let(:url) { 'https://foo.bar/baz' }
+    let(:data) { { foo: 'bar' } }
+    let(:body) { { bar: 'foo' } }
+
+    context 'with successful response' do
+      it 'returns the response body' do
+        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 200, body: JSON.generate(body))
+        expect(send_request).to eq(body)
+      end
+    end
+
+    context 'with 400 response' do
+      it 'raises an Anthropic::BadRequestError' do
+        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 400, body: JSON.generate(body))
+        expect { send_request }.to raise_error(Anthropic::BadRequestError)
+      end
+    end
+
+    context 'with 401 response' do
+      it 'raises an Anthropic::AuthenticationError' do
+        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 401, body: JSON.generate(body))
+        expect { send_request }.to raise_error(Anthropic::AuthenticationError)
+      end
+    end
+
+    context 'with 403 response' do
+      it 'raises an Anthropic::PermissionDeniedError' do
+        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 403, body: JSON.generate(body))
+        expect { send_request }.to raise_error(Anthropic::PermissionDeniedError)
+      end
+    end
+
+    context 'with 404 response' do
+      it 'raises an Anthropic::NotFoundError' do
+        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 404, body: JSON.generate(body))
+        expect { send_request }.to raise_error(Anthropic::NotFoundError)
+      end
+    end
+
+    context 'with 409 response' do
+      it 'raises an Anthropic::ConflictError' do
+        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 409, body: JSON.generate(body))
+        expect { send_request }.to raise_error(Anthropic::ConflictError)
+      end
+    end
+
+    context 'with 422 response' do
+      it 'raises an Anthropic::UnprocessableEntityError' do
+        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 422, body: JSON.generate(body))
+        expect { send_request }.to raise_error(Anthropic::UnprocessableEntityError)
+      end
+    end
+
+    context 'with 429 response' do
+      it 'raises an Anthropic::RateLimitError' do
+        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 429, body: JSON.generate(body))
+        expect { send_request }.to raise_error(Anthropic::RateLimitError)
+      end
+    end
+
+    context 'with 500 response' do
+      it 'raises an Anthropic::InternalServerError' do
+        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 500, body: JSON.generate(body))
+        expect { send_request }.to raise_error(Anthropic::InternalServerError)
+      end
+    end
+  end
+end

--- a/spec/lib/anthropic/completions_spec.rb
+++ b/spec/lib/anthropic/completions_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe Anthropic::Completions do
+  subject(:completions_api) { described_class.new }
+
+  describe '#create' do
+    subject(:call_method) { completions_api.create(**params) }
+
+    context 'with invalid params' do
+      let(:params) { { model: 'foo' } }
+
+      it 'raises an error' do
+        expect { call_method }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with valid params' do
+      let(:params) do
+        {
+          model: 'claude-2.1',
+          prompt: 'foo',
+          max_tokens_to_sample: 1
+        }
+      end
+      let(:response_body) do
+        {
+          id: 'compl_0123',
+          type: 'completion',
+          completion: 'bar',
+          stop_reason: 'stop_sequence',
+          model: 'claude-2.1'
+        }
+      end
+
+      before do
+        stub_http_request(:post, 'https://api.anthropic.com/v1/complete').and_return(
+          status: 200,
+          body: JSON.generate(response_body)
+        )
+      end
+
+      it 'raises an error if the API version is not supported' do
+        allow(Anthropic).to receive(:api_version).and_return('2023-06-02')
+        expect { call_method }.to raise_error(Anthropic::Completions::UnsupportedApiVersionError)
+      end
+
+      it 'returns the response from the API' do
+        expect(call_method).to eq(response_body)
+      end
+    end
+  end
+end

--- a/spec/lib/anthropic_spec.rb
+++ b/spec/lib/anthropic_spec.rb
@@ -39,9 +39,45 @@ RSpec.describe Anthropic do
 
     let(:api_key) { 'foobar' }
 
-    it 'returns the API key' do
+    it 'sets the API key' do
       call_method
       expect(described_class.api_key).to eq(api_key)
+    end
+  end
+
+  describe '.api_version' do
+    subject(:call_method) { described_class.api_version }
+
+    let(:api_version) { '2023-06-01' }
+
+    before do
+      described_class.api_version = api_version
+    end
+
+    it 'returns the API version' do
+      expect(call_method).to eq(api_version)
+    end
+  end
+
+  describe '.api_version=' do
+    subject(:call_method) { described_class.api_version = api_version }
+
+    context 'when the version is nil' do
+      let(:api_version) { nil }
+
+      it 'sets the default API version' do
+        call_method
+        expect(described_class.api_version).to eq('2023-06-01')
+      end
+    end
+
+    context 'when the version is provided' do
+      let(:api_version) { '2023-12-25' }
+
+      it 'sets the API version' do
+        call_method
+        expect(described_class.api_version).to eq(api_version)
+      end
     end
   end
 end

--- a/spec/lib/anthropic_spec.rb
+++ b/spec/lib/anthropic_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe Anthropic do
       end
     end
 
-    let(:api_key) { 'foobar' }
+    let(:api_key) { 'test' }
+
+    after do
+      described_class.reset
+    end
 
     it 'sets the provided values' do
       setup
@@ -23,14 +27,33 @@ RSpec.describe Anthropic do
   describe '.api_key' do
     subject(:call_method) { described_class.api_key }
 
-    let(:api_key) { 'foobar' }
+    context 'when no API key has been set' do
+      # rubocop:disable RSpec/NestedGroups
+      context 'with the ANTHROPIC_API_KEY environment variable set' do
+        let(:api_key) { 'foobar' }
 
-    before do
-      described_class.api_key = api_key
+        it 'returns the API key from the environment variable' do
+          allow(ENV).to receive(:fetch).with('ANTHROPIC_API_KEY', nil).and_return(api_key)
+          expect(call_method).to eq(api_key)
+        end
+      end
+
+      context 'without the ANTHROPIC_API_KEY environment variable' do
+        it 'returns nil' do
+          allow(ENV).to receive(:fetch).with('ANTHROPIC_API_KEY', nil).and_return(nil)
+          expect(call_method).to be_nil
+        end
+      end
+      # rubocop:enable RSpec/NestedGroups
     end
 
-    it 'returns the API key' do
-      expect(call_method).to eq(api_key)
+    context 'when an API key has been set' do
+      let(:api_key) { 'foobar' }
+
+      it 'returns the API key' do
+        described_class.api_key = api_key
+        expect(call_method).to eq(api_key)
+      end
     end
   end
 
@@ -48,36 +71,44 @@ RSpec.describe Anthropic do
   describe '.api_version' do
     subject(:call_method) { described_class.api_version }
 
-    let(:api_version) { '2023-06-01' }
+    context 'when the version has not been set' do
+      # rubocop:disable RSpec/NestedGroups
+      context 'with the ANTHROPIC_API_VERSION environment variable set' do
+        let(:api_version) { '2023-12-25' }
 
-    before do
-      described_class.api_version = api_version
+        it 'returns the API version from the environment variable' do
+          allow(ENV).to receive(:fetch).with('ANTHROPIC_API_VERSION', '2023-06-01').and_return(api_version)
+          expect(call_method).to eq(api_version)
+        end
+      end
+
+      context 'without the ANTHROPIC_API_VERSION environment variable' do
+        it 'returns the default API version' do
+          allow(ENV).to receive(:fetch).with('ANTHROPIC_API_VERSION', '2023-06-01').and_return('2023-06-01')
+          expect(call_method).to eq('2023-06-01')
+        end
+      end
+      # rubocop:enable RSpec/NestedGroups
     end
 
-    it 'returns the API version' do
-      expect(call_method).to eq(api_version)
+    context 'when the version has been set' do
+      let(:api_version) { '2023-12-25' }
+
+      it 'returns the API version' do
+        described_class.api_version = api_version
+        expect(call_method).to eq(api_version)
+      end
     end
   end
 
   describe '.api_version=' do
     subject(:call_method) { described_class.api_version = api_version }
 
-    context 'when the version is nil' do
-      let(:api_version) { nil }
+    let(:api_version) { '2023-12-25' }
 
-      it 'sets the default API version' do
-        call_method
-        expect(described_class.api_version).to eq('2023-06-01')
-      end
-    end
-
-    context 'when the version is provided' do
-      let(:api_version) { '2023-12-25' }
-
-      it 'sets the API version' do
-        call_method
-        expect(described_class.api_version).to eq(api_version)
-      end
+    it 'sets the API version' do
+      call_method
+      expect(described_class.api_version).to eq(api_version)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'webmock/rspec'
+require 'httpx/adapters/webmock'
+
 Dir[File.expand_path('../lib/**/*.rb', __dir__)].each { |f| require f }
 
 RSpec.configure do |config|
@@ -13,3 +16,5 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+WebMock.enable!


### PR DESCRIPTION
## Description

This PR implements the initial integration with the completions API.

## Testing

Follow these steps to test this PR:

* Open the console: `bin/console`
* Set the API key: `Anthropic.api_key = 'foobar'`
  * Test reading API key and version from both config and environment variables.
* Create a completion:
```ruby
Anthropic.completions.create(
  model: 'claude-2',
  max_tokens_to_sample: 200,
  prompt: 'Human: Yo what up?\n\nAssistant:'
)
```
* Try passing in unsupported params.
```ruby
Anthropic.completions.create(
  model: 'claude-2',
  max_tokens_to_sample: 200,
  prompt: 'Human: Yo what up?\n\nAssistant:',
  foo: 'bar'
)
```
* Try omitting required params
```ruby
Anthropic.completions.create(
  max_tokens_to_sample: 200,
  prompt: 'Human: Yo what up?\n\nAssistant:'
)
```
* Try passing in invalid params.
```ruby
Anthropic.completions.create(
  model: 'claude-2',
  max_tokens_to_sample: 'foobar',
  prompt: 'Human: Yo what up?\n\nAssistant:'
)
```
