### PR TITLE
Add streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ Anthropic.completions.create(
 # }
 ```
 
+Alternatively, you can stream the response:
+
+```ruby
+Anthropic.completions.create(model: 'claude-2', max_tokens_to_sample: 200, prompt: 'Human: Yo what up?\n\nAssistant:') do |event|
+  puts event
+end
+
+# Output =>
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>" Hello", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>"!", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>" Not", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>" much", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>",", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>" just", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>" chatting", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>" with", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>" people", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>".", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>" How", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>" about", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>" you", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>"?", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+# {:type=>"completion", :id=>"compl_01G6cEfdZtLEEJVRzwUShiDY", :completion=>"", :stop_reason=>"stop_sequence", :model=>"claude-2.1", :stop=>"\n\nHuman:", :log_id=>"compl_01G6cEfdZtLEEJVRzwUShiDY"}
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/anthropic/completions.rb
+++ b/lib/anthropic/completions.rb
@@ -28,9 +28,11 @@ module Anthropic
       @endpoint = 'https://api.anthropic.com/v1/complete'
     end
 
-    def create(**params)
+    def create(**params, &)
       JSON::Validator.validate!(schema_for_api_version, params)
-      Anthropic::Client.post(endpoint, params)
+      return Anthropic::Client.post(endpoint, params) unless params[:stream]
+
+      Anthropic::Client.post_as_stream(endpoint, params, &)
     rescue JSON::Schema::ValidationError => error
       raise ArgumentError, error.message
     end

--- a/spec/lib/anthropic/client_spec.rb
+++ b/spec/lib/anthropic/client_spec.rb
@@ -10,63 +10,166 @@ RSpec.describe Anthropic::Client do
 
     context 'with successful response' do
       it 'returns the response body' do
-        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 200, body: JSON.generate(body))
+        stub_http_request(:post, url).and_return(status: 200, body: JSON.generate(body))
         expect(send_request).to eq(body)
       end
     end
 
     context 'with 400 response' do
       it 'raises an Anthropic::BadRequestError' do
-        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 400, body: JSON.generate(body))
+        stub_http_request(:post, url).and_return(status: 400, body: JSON.generate(body))
         expect { send_request }.to raise_error(Anthropic::BadRequestError)
       end
     end
 
     context 'with 401 response' do
       it 'raises an Anthropic::AuthenticationError' do
-        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 401, body: JSON.generate(body))
+        stub_http_request(:post, url).and_return(status: 401, body: JSON.generate(body))
         expect { send_request }.to raise_error(Anthropic::AuthenticationError)
       end
     end
 
     context 'with 403 response' do
       it 'raises an Anthropic::PermissionDeniedError' do
-        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 403, body: JSON.generate(body))
+        stub_http_request(:post, url).and_return(status: 403, body: JSON.generate(body))
         expect { send_request }.to raise_error(Anthropic::PermissionDeniedError)
       end
     end
 
     context 'with 404 response' do
       it 'raises an Anthropic::NotFoundError' do
-        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 404, body: JSON.generate(body))
+        stub_http_request(:post, url).and_return(status: 404, body: JSON.generate(body))
         expect { send_request }.to raise_error(Anthropic::NotFoundError)
       end
     end
 
     context 'with 409 response' do
       it 'raises an Anthropic::ConflictError' do
-        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 409, body: JSON.generate(body))
+        stub_http_request(:post, url).and_return(status: 409, body: JSON.generate(body))
         expect { send_request }.to raise_error(Anthropic::ConflictError)
       end
     end
 
     context 'with 422 response' do
       it 'raises an Anthropic::UnprocessableEntityError' do
-        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 422, body: JSON.generate(body))
+        stub_http_request(:post, url).and_return(status: 422, body: JSON.generate(body))
         expect { send_request }.to raise_error(Anthropic::UnprocessableEntityError)
       end
     end
 
     context 'with 429 response' do
       it 'raises an Anthropic::RateLimitError' do
-        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 429, body: JSON.generate(body))
+        stub_http_request(:post, url).and_return(status: 429, body: JSON.generate(body))
         expect { send_request }.to raise_error(Anthropic::RateLimitError)
       end
     end
 
     context 'with 500 response' do
       it 'raises an Anthropic::InternalServerError' do
-        stub_http_request(:post, 'https://foo.bar/baz').and_return(status: 500, body: JSON.generate(body))
+        stub_http_request(:post, url).and_return(status: 500, body: JSON.generate(body))
+        expect { send_request }.to raise_error(Anthropic::InternalServerError)
+      end
+    end
+  end
+
+  describe '.post_as_stream' do
+    subject(:send_request) { described_class.post_as_stream(url, data) { |event| events << event } }
+
+    let(:url) { 'https://foo.bar/baz' }
+    let(:data) { { foo: 'bar' } }
+    let(:events) { [] }
+    let(:body) do
+      'data: {"bar":"foo"}'
+    end
+
+    context 'with successful response' do
+      # rubocop:disable RSpec/NestedGroups
+      context 'when event type ping' do
+        let(:body) do
+          'data: {"bar":"foo","type":"ping"}'
+        end
+
+        it 'does not yield the event to the block' do
+          stub_http_request(:post, url).to_return(status: 200, body:)
+          send_request
+          expect(events).to be_empty
+        end
+      end
+
+      context 'when event type error' do
+        let(:body) do
+          'data: {"bar":"foo","type":"error"}'
+        end
+
+        it 'does not yield the event to the block' do
+          stub_http_request(:post, url).to_return(status: 200, body:)
+          send_request
+          expect(events).to be_empty
+        end
+      end
+
+      context 'when all other event types' do
+        it 'yields the response to the block' do
+          stub_http_request(:post, url).to_return(status: 200, body:)
+          send_request
+          expect(events).to eq([{ bar: 'foo' }])
+        end
+      end
+      # rubocop:enable RSpec/NestedGroups
+    end
+
+    context 'with 400 response' do
+      it 'raises an Anthropic::BadRequestError' do
+        stub_http_request(:post, url).and_return(status: 400, body:)
+        expect { send_request }.to raise_error(Anthropic::BadRequestError)
+      end
+    end
+
+    context 'with 401 response' do
+      it 'raises an Anthropic::AuthenticationError' do
+        stub_http_request(:post, url).and_return(status: 401, body:)
+        expect { send_request }.to raise_error(Anthropic::AuthenticationError)
+      end
+    end
+
+    context 'with 403 response' do
+      it 'raises an Anthropic::PermissionDeniedError' do
+        stub_http_request(:post, url).and_return(status: 403, body:)
+        expect { send_request }.to raise_error(Anthropic::PermissionDeniedError)
+      end
+    end
+
+    context 'with 404 response' do
+      it 'raises an Anthropic::NotFoundError' do
+        stub_http_request(:post, url).and_return(status: 404, body:)
+        expect { send_request }.to raise_error(Anthropic::NotFoundError)
+      end
+    end
+
+    context 'with 409 response' do
+      it 'raises an Anthropic::ConflictError' do
+        stub_http_request(:post, url).and_return(status: 409, body:)
+        expect { send_request }.to raise_error(Anthropic::ConflictError)
+      end
+    end
+
+    context 'with 422 response' do
+      it 'raises an Anthropic::UnprocessableEntityError' do
+        stub_http_request(:post, url).and_return(status: 422, body:)
+        expect { send_request }.to raise_error(Anthropic::UnprocessableEntityError)
+      end
+    end
+
+    context 'with 429 response' do
+      it 'raises an Anthropic::RateLimitError' do
+        stub_http_request(:post, url).and_return(status: 429, body:)
+        expect { send_request }.to raise_error(Anthropic::RateLimitError)
+      end
+    end
+
+    context 'with 500 response' do
+      it 'raises an Anthropic::InternalServerError' do
+        stub_http_request(:post, url).and_return(status: 500, body:)
         expect { send_request }.to raise_error(Anthropic::InternalServerError)
       end
     end

--- a/spec/lib/anthropic/completions_spec.rb
+++ b/spec/lib/anthropic/completions_spec.rb
@@ -15,38 +15,65 @@ RSpec.describe Anthropic::Completions do
     end
 
     context 'with valid params' do
-      let(:params) do
-        {
-          model: 'claude-2.1',
-          prompt: 'foo',
-          max_tokens_to_sample: 1
-        }
-      end
-      let(:response_body) do
-        {
-          id: 'compl_0123',
-          type: 'completion',
-          completion: 'bar',
-          stop_reason: 'stop_sequence',
-          model: 'claude-2.1'
-        }
+      # rubocop:disable RSpec/NestedGroups
+      context 'when stream option is set to true' do
+        subject(:call_method) { completions_api.create(**params) { |event| events << event } }
+
+        let(:params) do
+          {
+            model: 'claude-2.1',
+            prompt: 'foo',
+            max_tokens_to_sample: 1,
+            stream: true
+          }
+        end
+        let(:body) { 'data: {"bar":"foo"}' }
+        let(:events) { [] }
+
+        it 'raises an error if the API version is not supported' do
+          allow(Anthropic).to receive(:api_version).and_return('2023-06-02')
+          expect { call_method }.to raise_error(Anthropic::Completions::UnsupportedApiVersionError)
+        end
+
+        it 'receives streamed events' do
+          stub_http_request(:post, 'https://api.anthropic.com/v1/complete').to_return(status: 200, body:)
+          call_method
+          expect(events).to eq([{ bar: 'foo' }])
+        end
       end
 
-      before do
-        stub_http_request(:post, 'https://api.anthropic.com/v1/complete').and_return(
-          status: 200,
-          body: JSON.generate(response_body)
-        )
-      end
+      context 'when stream option is set to false or not provided' do
+        let(:params) do
+          {
+            model: 'claude-2.1',
+            prompt: 'foo',
+            max_tokens_to_sample: 1
+          }
+        end
+        let(:response_body) do
+          {
+            id: 'compl_0123',
+            type: 'completion',
+            completion: 'bar',
+            stop_reason: 'stop_sequence',
+            model: 'claude-2.1'
+          }
+        end
 
-      it 'raises an error if the API version is not supported' do
-        allow(Anthropic).to receive(:api_version).and_return('2023-06-02')
-        expect { call_method }.to raise_error(Anthropic::Completions::UnsupportedApiVersionError)
-      end
+        it 'raises an error if the API version is not supported' do
+          allow(Anthropic).to receive(:api_version).and_return('2023-06-02')
+          expect { call_method }.to raise_error(Anthropic::Completions::UnsupportedApiVersionError)
+        end
 
-      it 'returns the response from the API' do
-        expect(call_method).to eq(response_body)
+        it 'returns the response from the API' do
+          stub_http_request(:post, 'https://api.anthropic.com/v1/complete').and_return(
+            status: 200,
+            body: JSON.generate(response_body)
+          )
+          expect(call_method).to eq(response_body)
+        end
       end
+      # rubocop:enable RSpec/NestedGroups
     end
   end
 end


### PR DESCRIPTION
## Description

This PR adds streaming support for completions API.

## Testing

Follow these steps to test this PR:

* Regression test existing functionality.
* Create a streamed completion request and verify functions as expected.
* Create a streamed completion request with an invalid API key (test failure response from API).

