### PR TITLE
Rename client request errors

### DIFF
--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -22,11 +22,11 @@ module Anthropic
       when 200
         response_body
       when 400
-        raise Anthropic::Errors::BadRequestError, response_body
+        raise Anthropic::Errors::InvalidRequestError, response_body
       when 401
         raise Anthropic::Errors::AuthenticationError, response_body
       when 403
-        raise Anthropic::Errors::PermissionDeniedError, response_body
+        raise Anthropic::Errors::PermissionError, response_body
       when 404
         raise Anthropic::Errors::NotFoundError, response_body
       when 409
@@ -36,10 +36,13 @@ module Anthropic
       when 429
         raise Anthropic::Errors::RateLimitError, response_body
       when 500
-        raise Anthropic::Errors::InternalServerError, response_body
+        raise Anthropic::Errors::ApiError, response_body
+      when 529
+        raise Anthropic::Errors::OverloadedError, response_body
       end
     end
 
+    # rubocop:disable Metrics/PerceivedComplexity
     def self.post_as_stream(url, data, headers = {})
       response = HTTPX.plugin(:stream).with(
         headers: {
@@ -61,11 +64,11 @@ module Anthropic
     rescue HTTPX::HTTPError => error
       case error.response.status
       when 400
-        raise Anthropic::Errors::BadRequestError
+        raise Anthropic::Errors::InvalidRequestError
       when 401
         raise Anthropic::Errors::AuthenticationError
       when 403
-        raise Anthropic::Errors::PermissionDeniedError
+        raise Anthropic::Errors::PermissionError
       when 404
         raise Anthropic::Errors::NotFoundError
       when 409
@@ -75,9 +78,11 @@ module Anthropic
       when 429
         raise Anthropic::Errors::RateLimitError
       when 500
-        raise Anthropic::Errors::InternalServerError
+        raise Anthropic::Errors::ApiError
+      when 529
+        raise Anthropic::Errors::OverloadedError
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   end
 end

--- a/lib/anthropic/errors/client.rb
+++ b/lib/anthropic/errors/client.rb
@@ -4,27 +4,38 @@ module Anthropic
   module Errors
     ##
     # Error when the request is malformed.
-    class BadRequestError < StandardError; end
+    class InvalidRequestError < StandardError; end
+
     ##
     # Error when the API key is invalid.
     class AuthenticationError < StandardError; end
+
     ##
     # Error when the account does not have permission for the operation.
-    class PermissionDeniedError < StandardError; end
+    class PermissionError < StandardError; end
+
     ##
     # Error when the resource is not found.
     class NotFoundError < StandardError; end
+
     ##
     # Error when the resource already exists.
     class ConflictError < StandardError; end
+
     ##
     # Error when the resource cannot be processed.
     class UnprocessableEntityError < StandardError; end
+
     ##
     # Error when the request exceeds the rate limit.
     class RateLimitError < StandardError; end
+
     ##
     # Error when the server experienced an internal error.
-    class InternalServerError < StandardError; end
+    class ApiError < StandardError; end
+
+    ##
+    # Error when the API servers are overloaded.
+    class OverloadedError < StandardError; end
   end
 end

--- a/spec/lib/anthropic/client_spec.rb
+++ b/spec/lib/anthropic/client_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Anthropic::Client do
     end
 
     context 'with 400 response' do
-      it 'raises an Anthropic::BadRequestError' do
+      it 'raises an Anthropic::InvalidRequestError' do
         stub_http_request(:post, url).and_return(status: 400, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::BadRequestError)
+        expect { send_request }.to raise_error(Anthropic::Errors::InvalidRequestError)
       end
     end
 
@@ -30,9 +30,9 @@ RSpec.describe Anthropic::Client do
     end
 
     context 'with 403 response' do
-      it 'raises an Anthropic::PermissionDeniedError' do
+      it 'raises an Anthropic::PermissionError' do
         stub_http_request(:post, url).and_return(status: 403, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::PermissionDeniedError)
+        expect { send_request }.to raise_error(Anthropic::Errors::PermissionError)
       end
     end
 
@@ -65,9 +65,16 @@ RSpec.describe Anthropic::Client do
     end
 
     context 'with 500 response' do
-      it 'raises an Anthropic::InternalServerError' do
+      it 'raises an Anthropic::ApiError' do
         stub_http_request(:post, url).and_return(status: 500, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::InternalServerError)
+        expect { send_request }.to raise_error(Anthropic::Errors::ApiError)
+      end
+    end
+
+    context 'with 529 response' do
+      it 'raises an Anthropic::OverloadedError' do
+        stub_http_request(:post, url).and_return(status: 529, body: JSON.generate(body))
+        expect { send_request }.to raise_error(Anthropic::Errors::OverloadedError)
       end
     end
   end
@@ -119,9 +126,9 @@ RSpec.describe Anthropic::Client do
     end
 
     context 'with 400 response' do
-      it 'raises an Anthropic::BadRequestError' do
+      it 'raises an Anthropic::InvalidRequestError' do
         stub_http_request(:post, url).and_return(status: 400, body:)
-        expect { send_request }.to raise_error(Anthropic::Errors::BadRequestError)
+        expect { send_request }.to raise_error(Anthropic::Errors::InvalidRequestError)
       end
     end
 
@@ -133,9 +140,9 @@ RSpec.describe Anthropic::Client do
     end
 
     context 'with 403 response' do
-      it 'raises an Anthropic::PermissionDeniedError' do
+      it 'raises an Anthropic::PermissionError' do
         stub_http_request(:post, url).and_return(status: 403, body:)
-        expect { send_request }.to raise_error(Anthropic::Errors::PermissionDeniedError)
+        expect { send_request }.to raise_error(Anthropic::Errors::PermissionError)
       end
     end
 
@@ -168,9 +175,16 @@ RSpec.describe Anthropic::Client do
     end
 
     context 'with 500 response' do
-      it 'raises an Anthropic::InternalServerError' do
+      it 'raises an Anthropic::ApiError' do
         stub_http_request(:post, url).and_return(status: 500, body:)
-        expect { send_request }.to raise_error(Anthropic::Errors::InternalServerError)
+        expect { send_request }.to raise_error(Anthropic::Errors::ApiError)
+      end
+    end
+
+    context 'with 529 response' do
+      it 'raises an Anthropic::OverloadedError' do
+        stub_http_request(:post, url).and_return(status: 529, body:)
+        expect { send_request }.to raise_error(Anthropic::Errors::OverloadedError)
       end
     end
   end


### PR DESCRIPTION
## Description

This PR updates client request errors to more closely align with the official error names.
