### PR TITLE
Use data objects to encapsulate responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,32 +36,58 @@ You can send a request to the Messages API.
 Anthropic.messages.create(model: 'claude-2.1', max_tokens: 200, messages: [{role: 'user', content: 'Yo what up?'}])
 
 # Output =>
-# {
-#   id: "msg_013ePdwEkb4RMC1hCE61Hbm8",
-#   type: "message",
-#   role: "assistant",
-#   content: [{type: "text", text: "Hello! Not much up with me, just chatting. How about you?"}],
-#   model: "claude-2.1",
-#   stop_reason: "end_turn",
-#   stop_sequence: nil
-# }
+#<data Anthropic::Client::Response status="success", body={:id=>"msg_01UqHiw6oFLjMYiLV8hkXsrR", :type=>"message", :role=>"assistant", :model=>"claude-2.1", :content=>[{:type=>"text", :text=>"Hello! Not much up with me, just chatting with you. How's it going?"}], :stop_reason=>"end_turn", :stop_sequence=>nil, :usage=>{:input_tokens=>13, :output_tokens=>22}}>
 ```
 
 Alternatively, you can stream the response:
 
 ```ruby
-Anthropic.messages.create(model: 'claude-2.1', max_tokens: 200, messages: [{role: 'user', content: 'Yo what up?'}], stream: true) do |event|
+options = {
+  model: 'claude-2.1',
+  max_tokens: 200,
+  messages: [{role: 'user', content: 'Yo what up?'}],
+  stream: true
+}
+
+Anthropic.messages.create(**options) do |event|
   puts event
 end
 
 # Output =>
-# { type: 'message_start', message: { id: 'msg_012pkeozZynwyNvSagwL7kMw', type: 'message', role: 'assistant', content: [], model: 'claude-2.1', stop_reason: nil, stop_sequence: nil } }
-# { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }
-# { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } }
-# { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: '.' } }
-# { type: 'content_block_stop', index: 0 }
-# { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: nil } }
-# { type: 'message_stop' }
+#<data Anthropic::Client::Response status="success", body={:type=>"message_start", :message=>{:id=>"msg_01EsYcQkBJrHrtgpY5ZcLzvf", :type=>"message", :role=>"assistant", :model=>"claude-2.1", :content=>[], :stop_reason=>nil, :stop_sequence=>nil, :usage=>{:input_tokens=>13, :output_tokens=>1}}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_start", :index=>0, :content_block=>{:type=>"text", :text=>""}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>"Hello"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>"!"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" Not"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" much"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" up"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" with"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" me"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>","}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" I"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>"'m"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" an"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" AI"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" assistant"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" create"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>"d by"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>" An"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>"throp"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>"ic"}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_delta", :index=>0, :delta=>{:type=>"text_delta", :text=>"."}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"content_block_stop", :index=>0}>
+#<data Anthropic::Client::Response status="success", body={:type=>"message_delta", :delta=>{:stop_reason=>"end_turn", :stop_sequence=>nil}, :usage=>{:output_tokens=>23}}>
+#<data Anthropic::Client::Response status="success", body={:type=>"message_stop"}>
+
+# Or, if you just want to print the text content:
+Anthropic.messages.create(**options) do |event|
+  next unless event.body[:type] == 'content_block_delta'
+
+  print event.body[:delta][:text]
+end
+
+# Output =>
+# Hello! Not much up with me, I'm an AI assistant created by Anthropic.
 ```
 
 You can also experiment with the new tools beta by passing the `beta` name when calling the API. This will ensure each request includes the correct beta header and validate properly.
@@ -103,38 +129,41 @@ Anthropic.completions.create(
 )
 
 # Output =>
-# {
-#   completion: "Hello! Not much going on with me, just chatting. How about you?",
-#   stop_reason: "stop_sequence",
-#   model: "claude-2.1",
-#   stop: "\n\nHuman:",
-#   log_id: "2496914137c520ec2b4ae8315864bcf3a4c6ce9f2e3c96e13be4c004587313ca"
-# }
+#<data Anthropic::Client::Response status="success", body={:type=>"completion", :id=>"compl_01Y9ptPR7xGHaH9rC3ffJExU", :completion=>" Hello! Not much going on here. How about you?", :stop_reason=>"stop_sequence", :model=>"claude-2.1", :stop=>"\n\nHuman:", :log_id=>"compl_01Y9ptPR7xGHaH9rC3ffJExU"}>
 ```
 
 Alternatively, you can stream the response:
 
 ```ruby
-Anthropic.completions.create(model: 'claude-2', max_tokens_to_sample: 200, prompt: 'Human: Yo what up?\n\nAssistant:', stream: true) do |event|
+options = {
+  model: 'claude-2',
+  max_tokens_to_sample: 200,
+  prompt: 'Human: Yo what up?\n\nAssistant:',
+  stream: true
+}
+
+Anthropic.completions.create(**options) do |event|
   puts event
 end
 
 # Output =>
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ' Hello', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: '!', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ' Not', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ' much', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ',', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ' just', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ' chatting', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ' with', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ' people', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: '.', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ' How', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ' about', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: ' you', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: '?', stop_reason: nil, model: 'claude-2.1', stop: nil, log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
-# { type: 'completion', id: 'compl_01G6cEfdZtLEEJVRzwUShiDY', completion: '', stop_reason: 'stop_sequence', model: 'claude-2.1', stop: "\n\nHuman:", log_id: 'compl_01G6cEfdZtLEEJVRzwUShiDY' }
+#<data Anthropic::Client::Response status="success", body={:type=>"completion", :id=>"compl_015AktggW7tcM4w11YpkuMbP", :completion=>" Hello", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_015AktggW7tcM4w11YpkuMbP"}>
+#<data Anthropic::Client::Response status="success", body={:type=>"completion", :id=>"compl_015AktggW7tcM4w11YpkuMbP", :completion=>"!", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_015AktggW7tcM4w11YpkuMbP"}>
+#<data Anthropic::Client::Response status="success", body={:type=>"completion", :id=>"compl_015AktggW7tcM4w11YpkuMbP", :completion=>" Not", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_015AktggW7tcM4w11YpkuMbP"}>
+#<data Anthropic::Client::Response status="success", body={:type=>"completion", :id=>"compl_015AktggW7tcM4w11YpkuMbP", :completion=>" much", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_015AktggW7tcM4w11YpkuMbP"}>
+#<data Anthropic::Client::Response status="success", body={:type=>"completion", :id=>"compl_015AktggW7tcM4w11YpkuMbP", :completion=>" going", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_015AktggW7tcM4w11YpkuMbP"}>
+#<data Anthropic::Client::Response status="success", body={:type=>"completion", :id=>"compl_015AktggW7tcM4w11YpkuMbP", :completion=>" on", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_015AktggW7tcM4w11YpkuMbP"}>
+#<data Anthropic::Client::Response status="success", body={:type=>"completion", :id=>"compl_015AktggW7tcM4w11YpkuMbP", :completion=>" here", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_015AktggW7tcM4w11YpkuMbP"}>
+#<data Anthropic::Client::Response status="success", body={:type=>"completion", :id=>"compl_015AktggW7tcM4w11YpkuMbP", :completion=>".", :stop_reason=>nil, :model=>"claude-2.1", :stop=>nil, :log_id=>"compl_015AktggW7tcM4w11YpkuMbP"}>
+#<data Anthropic::Client::Response status="success", body={:type=>"completion", :id=>"compl_015AktggW7tcM4w11YpkuMbP", :completion=>"", :stop_reason=>"stop_sequence", :model=>"claude-2.1", :stop=>"\n\nHuman:", :log_id=>"compl_015AktggW7tcM4w11YpkuMbP"}>
+
+# Or, if you just want to print the text content:
+Anthropic.completions.create(**options) do |event|
+  print event.body[:completion]
+end
+
+# Output =>
+# Hello! Not much, just chatting with you. How's it going?
 ```
 
 ## Installation

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -6,6 +6,8 @@ module Anthropic
   ##
   # Provides a client for sending HTTP requests.
   class Client
+    Response = Data.define(:status, :body)
+
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
     def self.post(url, data, headers = {})
       response = HTTPX.with(
@@ -16,29 +18,29 @@ module Anthropic
         }.merge(headers)
       ).post(url, json: data)
 
-      response_body = JSON.parse(response.body, symbolize_names: true)
+      response_data = build_response(response.body)
 
       case response.status
       when 200
-        response_body
+        response_data
       when 400
-        raise Anthropic::Errors::InvalidRequestError, response_body
+        raise Anthropic::Errors::InvalidRequestError, response_data
       when 401
-        raise Anthropic::Errors::AuthenticationError, response_body
+        raise Anthropic::Errors::AuthenticationError, response_data
       when 403
-        raise Anthropic::Errors::PermissionError, response_body
+        raise Anthropic::Errors::PermissionError, response_data
       when 404
-        raise Anthropic::Errors::NotFoundError, response_body
+        raise Anthropic::Errors::NotFoundError, response_data
       when 409
-        raise Anthropic::Errors::ConflictError, response_body
+        raise Anthropic::Errors::ConflictError, response_data
       when 422
-        raise Anthropic::Errors::UnprocessableEntityError, response_body
+        raise Anthropic::Errors::UnprocessableEntityError, response_data
       when 429
-        raise Anthropic::Errors::RateLimitError, response_body
+        raise Anthropic::Errors::RateLimitError, response_data
       when 500
-        raise Anthropic::Errors::ApiError, response_body
+        raise Anthropic::Errors::ApiError, response_data
       when 529
-        raise Anthropic::Errors::OverloadedError, response_body
+        raise Anthropic::Errors::OverloadedError, response_data
       end
     end
 
@@ -53,13 +55,13 @@ module Anthropic
       ).post(url, json: data, stream: true)
 
       response.each_line do |line|
-        event, data = line.split(/(\w+\b:\s)/)[1..2]
-        next unless event && data
+        type, event = line.split(/(\w+\b:\s)/)[1..2]
 
-        if event.start_with?('data')
-          formatted_data = JSON.parse(data, symbolize_names: true)
-          yield formatted_data unless %w[ping error].include?(formatted_data[:type])
-        end
+        next unless type&.start_with?('data') && event
+
+        response_data = build_response(event)
+
+        yield response_data unless %w[ping error].include?(response_data.body[:type])
       end
     rescue HTTPX::HTTPError => error
       case error.response.status
@@ -84,5 +86,15 @@ module Anthropic
       end
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+    class << self
+      private
+
+      def build_response(response)
+        response_hash = JSON.parse(response, symbolize_names: true)
+        status = response_hash[:type] == 'error' ? 'failure' : 'success'
+        Anthropic::Client::Response.new(status:, body: response_hash)
+      end
+    end
   end
 end

--- a/spec/lib/anthropic/client_spec.rb
+++ b/spec/lib/anthropic/client_spec.rb
@@ -1,190 +1,331 @@
 # frozen_string_literal: true
 
 RSpec.describe Anthropic::Client do
-  describe '.post' do
-    subject(:send_request) { described_class.post(url, data) }
-
-    let(:url) { 'https://foo.bar/baz' }
-    let(:data) { { foo: 'bar' } }
-    let(:body) { { bar: 'foo' } }
-
-    context 'with successful response' do
-      it 'returns the response body' do
-        stub_http_request(:post, url).and_return(status: 200, body: JSON.generate(body))
-        expect(send_request).to eq(body)
-      end
-    end
-
+  shared_examples 'handles errors from the API' do
     context 'with 400 response' do
-      it 'raises an Anthropic::InvalidRequestError' do
-        stub_http_request(:post, url).and_return(status: 400, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::InvalidRequestError)
-      end
-    end
-
-    context 'with 401 response' do
-      it 'raises an Anthropic::AuthenticationError' do
-        stub_http_request(:post, url).and_return(status: 401, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::AuthenticationError)
-      end
-    end
-
-    context 'with 403 response' do
-      it 'raises an Anthropic::PermissionError' do
-        stub_http_request(:post, url).and_return(status: 403, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::PermissionError)
-      end
-    end
-
-    context 'with 404 response' do
-      it 'raises an Anthropic::NotFoundError' do
-        stub_http_request(:post, url).and_return(status: 404, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::NotFoundError)
-      end
-    end
-
-    context 'with 409 response' do
-      it 'raises an Anthropic::ConflictError' do
-        stub_http_request(:post, url).and_return(status: 409, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::ConflictError)
-      end
-    end
-
-    context 'with 422 response' do
-      it 'raises an Anthropic::UnprocessableEntityError' do
-        stub_http_request(:post, url).and_return(status: 422, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::UnprocessableEntityError)
-      end
-    end
-
-    context 'with 429 response' do
-      it 'raises an Anthropic::RateLimitError' do
-        stub_http_request(:post, url).and_return(status: 429, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::RateLimitError)
-      end
-    end
-
-    context 'with 500 response' do
-      it 'raises an Anthropic::ApiError' do
-        stub_http_request(:post, url).and_return(status: 500, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::ApiError)
-      end
-    end
-
-    context 'with 529 response' do
-      it 'raises an Anthropic::OverloadedError' do
-        stub_http_request(:post, url).and_return(status: 529, body: JSON.generate(body))
-        expect { send_request }.to raise_error(Anthropic::Errors::OverloadedError)
-      end
-    end
-  end
-
-  describe '.post_as_stream' do
-    subject(:send_request) { described_class.post_as_stream(url, data) { |event| events << event } }
-
-    let(:url) { 'https://foo.bar/baz' }
-    let(:data) { { foo: 'bar' } }
-    let(:events) { [] }
-    let(:body) do
-      'data: {"bar":"foo"}'
-    end
-
-    context 'with successful response' do
-      # rubocop:disable RSpec/NestedGroups
-      context 'when event type ping' do
-        let(:body) do
-          'data: {"bar":"foo","type":"ping"}'
-        end
-
-        it 'does not yield the event to the block' do
-          stub_http_request(:post, url).to_return(status: 200, body:)
-          send_request
-          expect(events).to be_empty
-        end
+      let(:event) do
+        {
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            message: 'There was an issue with the format or content of your request.'
+          }
+        }
       end
 
-      context 'when event type error' do
-        let(:body) do
-          'data: {"bar":"foo","type":"error"}'
-        end
-
-        it 'does not yield the event to the block' do
-          stub_http_request(:post, url).to_return(status: 200, body:)
-          send_request
-          expect(events).to be_empty
-        end
-      end
-
-      context 'when all other event types' do
-        it 'yields the response to the block' do
-          stub_http_request(:post, url).to_return(status: 200, body:)
-          send_request
-          expect(events).to eq([{ bar: 'foo' }])
-        end
-      end
-      # rubocop:enable RSpec/NestedGroups
-    end
-
-    context 'with 400 response' do
-      it 'raises an Anthropic::InvalidRequestError' do
+      it 'raises an Anthropic::Errors::InvalidRequestError' do
         stub_http_request(:post, url).and_return(status: 400, body:)
         expect { send_request }.to raise_error(Anthropic::Errors::InvalidRequestError)
       end
     end
 
     context 'with 401 response' do
-      it 'raises an Anthropic::AuthenticationError' do
+      let(:event) do
+        {
+          type: 'error',
+          error: {
+            type: 'authentication_error',
+            message: 'There’s an issue with your API key.'
+          }
+        }
+      end
+
+      it 'raises an Anthropic::Errors::AuthenticationError' do
         stub_http_request(:post, url).and_return(status: 401, body:)
         expect { send_request }.to raise_error(Anthropic::Errors::AuthenticationError)
       end
     end
 
     context 'with 403 response' do
-      it 'raises an Anthropic::PermissionError' do
+      let(:event) do
+        {
+          type: 'error',
+          error: {
+            type: 'permission_error',
+            message: 'Your API key does not have permission to use the specified resource.'
+          }
+        }
+      end
+
+      it 'raises an Anthropic::Errors::PermissionError' do
         stub_http_request(:post, url).and_return(status: 403, body:)
         expect { send_request }.to raise_error(Anthropic::Errors::PermissionError)
       end
     end
 
     context 'with 404 response' do
-      it 'raises an Anthropic::NotFoundError' do
+      let(:event) do
+        {
+          type: 'error',
+          error: {
+            type: 'not_found_error',
+            message: 'The requested resource was not found.'
+          }
+        }
+      end
+
+      it 'raises an Anthropic::Errors::NotFoundError' do
         stub_http_request(:post, url).and_return(status: 404, body:)
         expect { send_request }.to raise_error(Anthropic::Errors::NotFoundError)
       end
     end
 
     context 'with 409 response' do
-      it 'raises an Anthropic::ConflictError' do
+      let(:event) do
+        {
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            message: 'There was an issue with the format or content of your request.'
+          }
+        }
+      end
+
+      it 'raises an Anthropic::Errors::ConflictError' do
         stub_http_request(:post, url).and_return(status: 409, body:)
         expect { send_request }.to raise_error(Anthropic::Errors::ConflictError)
       end
     end
 
     context 'with 422 response' do
-      it 'raises an Anthropic::UnprocessableEntityError' do
+      let(:event) do
+        {
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            message: 'There was an issue with the format or content of your request.'
+          }
+        }
+      end
+
+      it 'raises an Anthropic::Errors::UnprocessableEntityError' do
         stub_http_request(:post, url).and_return(status: 422, body:)
         expect { send_request }.to raise_error(Anthropic::Errors::UnprocessableEntityError)
       end
     end
 
     context 'with 429 response' do
-      it 'raises an Anthropic::RateLimitError' do
+      let(:event) do
+        {
+          type: 'error',
+          error: {
+            type: 'rate_limit_error',
+            message: 'Your account has hit a rate limit.'
+          }
+        }
+      end
+
+      it 'raises an Anthropic::Errors::RateLimitError' do
         stub_http_request(:post, url).and_return(status: 429, body:)
         expect { send_request }.to raise_error(Anthropic::Errors::RateLimitError)
       end
     end
 
     context 'with 500 response' do
-      it 'raises an Anthropic::ApiError' do
+      let(:event) do
+        {
+          type: 'error',
+          error: {
+            type: 'api_error',
+            message: 'An unexpected error has occurred internal to Anthropic’s systems.'
+          }
+        }
+      end
+
+      it 'raises an Anthropic::Errors::ApiError' do
         stub_http_request(:post, url).and_return(status: 500, body:)
         expect { send_request }.to raise_error(Anthropic::Errors::ApiError)
       end
     end
 
     context 'with 529 response' do
-      it 'raises an Anthropic::OverloadedError' do
+      let(:event) do
+        {
+          type: 'error',
+          error: {
+            type: 'overloaded_error',
+            message: 'Anthropic’s API is temporarily overloaded.'
+          }
+        }
+      end
+
+      it 'raises an Anthropic::Errors::OverloadedError' do
         stub_http_request(:post, url).and_return(status: 529, body:)
         expect { send_request }.to raise_error(Anthropic::Errors::OverloadedError)
+      end
+    end
+  end
+
+  describe '.post' do
+    subject(:send_request) { described_class.post(url, data) }
+
+    let(:url) { 'https://foo.bar/baz' }
+    let(:data) { { foo: 'bar' } }
+    let(:body) { JSON.generate(event) }
+
+    include_examples 'handles errors from the API'
+
+    context 'with successful response' do
+      let(:event) do
+        {
+          content: 'foo',
+          id: 'foo',
+          model: 'bar',
+          role: 'assistant',
+          stop_reason: 'baz',
+          stop_sequence: 'foobar',
+          type: 'message',
+          usage: 'foobarba'
+        }
+      end
+
+      it 'returns the response body' do
+        stub_http_request(:post, url).and_return(status: 200, body:)
+        expect(send_request).to eq(Anthropic::Client::Response.new('success', event))
+      end
+    end
+  end
+
+  describe '.post_as_stream' do
+    subject(:send_request) { described_class.post_as_stream(url, body) { |event| events << event } }
+
+    let(:url) { 'https://foo.bar/baz' }
+    let(:body) { "data: #{event.to_json}" }
+    let(:events) { [] }
+
+    include_examples 'handles errors from the API'
+
+    context 'when event type is ping' do
+      let(:event) { { type: 'ping' } }
+
+      it 'does not yield the event to the block' do
+        stub_http_request(:post, url).to_return(status: 200, body:)
+        send_request
+        expect(events).to be_empty
+      end
+    end
+
+    context 'when event type is error' do
+      let(:event) do
+        {
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            message: 'There was an issue with the format or content of your request.'
+          }
+        }
+      end
+
+      it 'does not yield the event to the block' do
+        stub_http_request(:post, url).to_return(status: 200, body:)
+        send_request
+        expect(events).to be_empty
+      end
+    end
+
+    context 'when event type is message_start' do
+      let(:event) do
+        {
+          type: 'message_start',
+          message: {
+            id: 'msg_1nZdL29xx5MUA1yADyHTEsnR8uuvGzszyY',
+            type: 'message',
+            role: 'assistant',
+            content: [],
+            model: 'claude-3-opus-20240229',
+            stop_reason: nil,
+            stop_sequence: nil
+          },
+          usage: {
+            input_tokens: 25,
+            output_tokens: 1
+          }
+        }
+      end
+
+      it 'yields the response to the block' do
+        stub_http_request(:post, url).to_return(status: 200, body:)
+        send_request
+        expect(events).to eq([Anthropic::Client::Response.new('success', event)])
+      end
+    end
+
+    context 'when event type is content_block_start' do
+      let(:event) do
+        {
+          type: 'content_block_start',
+          index: 0,
+          content_block: {
+            type: 'text',
+            text: ''
+          }
+        }
+      end
+
+      it 'yields the response to the block' do
+        stub_http_request(:post, url).to_return(status: 200, body:)
+        send_request
+        expect(events).to eq([Anthropic::Client::Response.new('success', event)])
+      end
+    end
+
+    context 'when event type is content_block_delta' do
+      let(:event) do
+        {
+          type: 'content_block_delta',
+          index: 0,
+          delta: {
+            type: 'text_delta',
+            text: 'Hello'
+          }
+        }
+      end
+
+      it 'yields the response to the block' do
+        stub_http_request(:post, url).to_return(status: 200, body:)
+        send_request
+        expect(events).to eq([Anthropic::Client::Response.new('success', event)])
+      end
+    end
+
+    context 'when event type is content_block_stop' do
+      let(:event) { { type: 'content_block_stop', index: 0 } }
+
+      it 'yields the response to the block' do
+        stub_http_request(:post, url).to_return(status: 200, body:)
+        send_request
+        expect(events).to eq([Anthropic::Client::Response.new('success', event)])
+      end
+    end
+
+    context 'when event type is message_delta' do
+      let(:event) do
+        {
+          type: 'message_delta',
+          delta: {
+            stop_reason: 'end_turn',
+            stop_sequence: nil
+          },
+          usage: {
+            output_tokens: 15
+          }
+        }
+      end
+
+      it 'yields the response to the block' do
+        stub_http_request(:post, url).to_return(status: 200, body:)
+        send_request
+        expect(events).to eq([Anthropic::Client::Response.new('success', event)])
+      end
+    end
+
+    context 'when event type is message_stop' do
+      let(:event) { { type: 'message_stop' } }
+
+      it 'yields the response to the block' do
+        stub_http_request(:post, url).to_return(status: 200, body:)
+        send_request
+        expect(events).to eq([Anthropic::Client::Response.new('success', event)])
       end
     end
   end


### PR DESCRIPTION
## Description

This PR refactors the client to return data objects with response details.

## Testing

Follow these steps to test this PR:

* Run the sanity check script and verify everything works as expected.
